### PR TITLE
CMS model 변경에 따른 ArticlePreview interface를 수정

### DIFF
--- a/src/components/common/ArticlePreview/ArticlePreview.tsx
+++ b/src/components/common/ArticlePreview/ArticlePreview.tsx
@@ -5,7 +5,7 @@ export interface ArticleType {
   title: string;
   slug: string;
   description: string;
-  categories: string[];
+  tag: string;
   thumbnail: { gatsbyImageData: IGatsbyImageData };
   createdAt: string;
 }
@@ -15,7 +15,7 @@ interface ArticlePreviewMdProps {
 }
 
 const ArticlePreview = ({ article }: ArticlePreviewMdProps) => {
-  const { categories, createdAt, slug, thumbnail, title } = article;
+  const { tag, createdAt, slug, thumbnail, title } = article;
 
   return (
     <Styled.ArticlePreview>
@@ -24,9 +24,7 @@ const ArticlePreview = ({ article }: ArticlePreviewMdProps) => {
           <Styled.Heading>{title}</Styled.Heading>
           <Styled.TagList>
             <Styled.Latest>최신</Styled.Latest>
-            {categories.map((category) => (
-              <Styled.Tag key={category}>{category}</Styled.Tag>
-            ))}
+            <Styled.Tag>{tag}</Styled.Tag>
           </Styled.TagList>
           <Styled.CreateAt>{createdAt}</Styled.CreateAt>
         </Styled.ContentWrapper>

--- a/src/components/home/ArticlePreviewLg/ArticlePreviewLg.tsx
+++ b/src/components/home/ArticlePreviewLg/ArticlePreviewLg.tsx
@@ -1,4 +1,4 @@
-import { ArticleType } from '@/components/common/ArticlePreviewMd/ArticlePreview';
+import { ArticleType } from '@/components/common/ArticlePreview/ArticlePreview';
 import * as Styled from './ArticlePreviewLg.styled';
 
 interface ArticlePreviewLgProps {
@@ -6,7 +6,7 @@ interface ArticlePreviewLgProps {
 }
 
 const ArticlePreviewLg = ({ article }: ArticlePreviewLgProps) => {
-  const { categories, createdAt, description, slug, thumbnail, title } = article;
+  const { tag, createdAt, description, slug, thumbnail, title } = article;
 
   return (
     <Styled.ArticlePreviewLg>
@@ -15,9 +15,7 @@ const ArticlePreviewLg = ({ article }: ArticlePreviewLgProps) => {
           <Styled.Heading>{title}</Styled.Heading>
           <Styled.TagList>
             <Styled.Latest>최신</Styled.Latest>
-            {categories.map((category) => (
-              <Styled.Tag key={category}>{category}</Styled.Tag>
-            ))}
+            <Styled.Tag>{tag}</Styled.Tag>
           </Styled.TagList>
           <Styled.Description>{description}</Styled.Description>
           <Styled.CreateAt>{createdAt}</Styled.CreateAt>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,7 +34,7 @@ export const query = graphql`
         title
         slug
         description
-        categories
+        tag
         thumbnail {
           gatsbyImageData
         }


### PR DESCRIPTION
## 변경사항

- 하나의 article당 tag를 하나만 달 수 있도록 정책이 수정되어 categories 필드를 tag 필드로 수정해주었습니다.
