### PR TITLE
Home페이지의 What we do 섹션의 기본 UI 구현

### DIFF
--- a/src/components/home/ArticleSection/ArticleSection.styled.ts
+++ b/src/components/home/ArticleSection/ArticleSection.styled.ts
@@ -9,7 +9,9 @@ export const ArticleSection = styled.section`
     grid-template-rows: auto 40.4rem;
     column-gap: 3rem;
     row-gap: 3.6rem;
-    padding: 5rem 0 0;
+    margin: 0 auto;
+    padding: 5rem 2.4rem 0;
+    max-width: 120rem;
 
     & > article {
       &:first-of-type {

--- a/src/components/home/Header/Header.styled.ts
+++ b/src/components/home/Header/Header.styled.ts
@@ -7,7 +7,9 @@ import StarSvg from '@/assets/svg/star.svg';
 
 export const Header = styled.header`
   ${({ theme }) => css`
+    margin: 0 auto;
     padding: 8.7rem 0 4rem;
+    max-width: 120rem;
 
     @media (max-width: ${theme.breakPoint.media.tablet}) {
       padding: 10.3rem 0 3.9rem;

--- a/src/components/home/HomeLayout/HomeLayout.styled.ts
+++ b/src/components/home/HomeLayout/HomeLayout.styled.ts
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+export const Layout = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  margin: 0 auto;
+  width: 100%;
+  min-height: 100vh;
+`;
+
+export const ContentsSection = styled.div`
+  flex-grow: 1;
+`;

--- a/src/components/home/HomeLayout/HomeLayout.tsx
+++ b/src/components/home/HomeLayout/HomeLayout.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+import { ThemeProvider } from '@emotion/react';
+import themes from '@/styles/themes';
+import { GlobalNavigationBar, Footer } from '@/components';
+import * as Styled from './HomeLayout.styled';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+const HomeLayout = ({ children }: LayoutProps) => {
+  return (
+    <ThemeProvider theme={themes}>
+      <GlobalNavigationBar />
+      <Styled.Layout>
+        <Styled.ContentsSection>{children}</Styled.ContentsSection>
+      </Styled.Layout>
+      <Footer />
+    </ThemeProvider>
+  );
+};
+
+export default HomeLayout;

--- a/src/components/home/WhatWeDo/WhatWeDo.styled.ts
+++ b/src/components/home/WhatWeDo/WhatWeDo.styled.ts
@@ -1,0 +1,148 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const WhatWeDoSection = styled.section`
+  ${({ theme }) =>
+    css`
+      margin: 10rem 0 0;
+
+      @media (max-width: ${theme.breakPoint.media.tablet}) {
+        margin: 8rem 0 0;
+      }
+
+      @media (max-width: ${theme.breakPoint.media.mobile}) {
+        margin: 4.8rem 0 0;
+      }
+    `}
+`;
+
+export const Heading = styled.h2`
+  ${({ theme }) => css`
+    ${theme.fonts.bold32};
+    text-align: center;
+  `}
+`;
+
+export const Background = styled.div`
+  ${({ theme }) => css`
+    background: ${theme.colors.light.black};
+    margin: 13.8rem 0 0;
+    padding: 14.8rem 9rem 0;
+    height: 31.2rem;
+
+    @media (max-width: ${theme.breakPoint.media.tablet}) {
+      padding: 13.2rem 3.9rem 0;
+      height: 22rem;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      position: relative;
+      margin: 10rem 0 0;
+      padding: 44.8rem 2rem 0;
+      height: 63.6rem;
+    }
+  `}
+`;
+
+export const WhatWeDoCardSection = styled.div`
+  ${({ theme }) => css`
+    ${theme.fonts.regular20};
+    position: relative;
+    margin: 0 auto;
+    color: ${theme.colors.light.white};
+    max-width: 102rem;
+
+    @media (max-width: ${theme.breakPoint.media.tablet}) {
+      ${theme.fonts.regular14};
+      word-break: keep-all;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      position: static;
+      padding: 0 1.2rem;
+    }
+  `}
+`;
+
+export const CardList = styled.ul`
+  ${({ theme }) =>
+    css`
+      position: absolute;
+      top: -22.6rem;
+      display: flex;
+      flex-flow: row nowrap;
+      justify-content: space-between;
+      width: 100%;
+
+      @media (max-width: ${theme.breakPoint.media.tablet}) {
+        top: -23rem;
+        gap: 2.2rem;
+      }
+
+      @media (max-width: ${theme.breakPoint.media.mobile}) {
+        top: -5.2rem;
+        left: 50%;
+        transform: translate3d(-50%, 0, 0);
+        flex-flow: column nowrap;
+        gap: 2.4rem;
+        width: calc(100% - 4rem);
+      }
+    `}
+`;
+
+interface WhatWeDoCardProps {
+  background: string;
+  color: string;
+}
+
+export const WhatWeDoCard = styled.li<WhatWeDoCardProps>`
+  ${({ theme, background, color }) => css`
+    background: ${background};
+    color: ${color};
+    padding: 2.1rem 2.1rem 4.6rem;
+    width: 32rem;
+    border-radius: 1rem;
+
+    @media (max-width: ${theme.breakPoint.media.tablet}) {
+      padding: 2.1rem 1.6rem 7.8rem;
+      width: 100%;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      padding: 2.1rem 2.1rem 3.3rem;
+    }
+  `}
+`;
+
+export const CardHeading = styled.h3`
+  ${({ theme }) => css`
+    ${theme.fonts.bold32};
+    margin-bottom: 0.9rem;
+
+    @media (max-width: ${theme.breakPoint.media.tablet}) {
+      ${theme.fonts.bold24};
+      margin-bottom: 1.3rem;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.bold24};
+      line-height: 1.5;
+      margin-bottom: 1.6rem;
+    }
+  `}
+`;
+
+export const CardDescription = styled.p`
+  ${({ theme }) => css`
+    ${theme.fonts.semibold20};
+
+    @media (max-width: ${theme.breakPoint.media.tablet}) {
+      ${theme.fonts.medium16};
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.medium20};
+      line-height: 1.5;
+    }
+  `}
+`;

--- a/src/components/home/WhatWeDo/WhatWeDo.tsx
+++ b/src/components/home/WhatWeDo/WhatWeDo.tsx
@@ -1,0 +1,33 @@
+import { colors } from '@/styles/themes/colors';
+import * as Styled from './WhatWeDo.styled';
+
+const WhatWeDo = () => {
+  return (
+    <Styled.WhatWeDoSection>
+      <Styled.Heading>What we do</Styled.Heading>
+      <Styled.Background>
+        <Styled.WhatWeDoCardSection>
+          매시업 디자인팀에서는 세미나, 스터디 팀 프로젝트까지 다양한 디자인 경험을 할 수 있습니다.
+          매 기수마다 선호도 조사를 통해 세미나 및 스터디 주제를 팀원들이 선정해서 꾸려나가고
+          있습니다.
+          <Styled.CardList>
+            <Styled.WhatWeDoCard background={colors.light.blue200} color={colors.light.white}>
+              <Styled.CardHeading>세미나/스터디</Styled.CardHeading>
+              <Styled.CardDescription>디자인 관련 스터디입니다.</Styled.CardDescription>
+            </Styled.WhatWeDoCard>
+            <Styled.WhatWeDoCard background={colors.light.yellow200} color={colors.light.black}>
+              <Styled.CardHeading>팀 프로젝트</Styled.CardHeading>
+              <Styled.CardDescription>매시업의 메인 활동입니다.</Styled.CardDescription>
+            </Styled.WhatWeDoCard>
+            <Styled.WhatWeDoCard background={colors.light.red200} color={colors.light.white}>
+              <Styled.CardHeading>장기 프로젝트</Styled.CardHeading>
+              <Styled.CardDescription>포트폴리오 제작 활동입니다.</Styled.CardDescription>
+            </Styled.WhatWeDoCard>
+          </Styled.CardList>
+        </Styled.WhatWeDoCardSection>
+      </Styled.Background>
+    </Styled.WhatWeDoSection>
+  );
+};
+
+export default WhatWeDo;

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -2,3 +2,4 @@ export { default as Header } from './Header/Header';
 export { default as ArticlePreviewLg } from './ArticlePreviewLg/ArticlePreviewLg';
 export { default as ArticleSection } from './ArticleSection/ArticleSection';
 export { default as HomeLayout } from './HomeLayout/HomeLayout';
+export { default as WhatWeDo } from './WhatWeDo/WhatWeDo';

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -1,3 +1,4 @@
 export { default as Header } from './Header/Header';
 export { default as ArticlePreviewLg } from './ArticlePreviewLg/ArticlePreviewLg';
 export { default as ArticleSection } from './ArticleSection/ArticleSection';
+export { default as HomeLayout } from './HomeLayout/HomeLayout';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql, HeadFC } from 'gatsby';
-import { ArticleSection, Header, HomeLayout } from '@/components';
+import { ArticleSection, Header, WhatWeDo, HomeLayout } from '@/components';
 import { ArticleType } from '@/components/common/ArticlePreview/ArticlePreview';
 
 interface IndexPageProps {
@@ -19,6 +19,7 @@ const IndexPage = ({ data }: IndexPageProps) => {
       <Header />
       <main>
         <ArticleSection allContentfulArticles={allContentfulArticles} />
+        <WhatWeDo />
       </main>
     </HomeLayout>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql, HeadFC } from 'gatsby';
-import { Layout, ArticleSection, Header } from '@/components';
+import { ArticleSection, Header, HomeLayout } from '@/components';
 import { ArticleType } from '@/components/common/ArticlePreview/ArticlePreview';
 
 interface IndexPageProps {
@@ -15,12 +15,12 @@ const IndexPage = ({ data }: IndexPageProps) => {
   const { allContentfulArticles } = data;
 
   return (
-    <Layout>
+    <HomeLayout>
       <Header />
       <main>
         <ArticleSection allContentfulArticles={allContentfulArticles} />
       </main>
-    </Layout>
+    </HomeLayout>
   );
 };
 


### PR DESCRIPTION
## 변경사항

- 기존에 전역에서 쓰기 위해 정의한 Layout 컴포넌트를 Home페이지에 적용중이었는데 What We do 섹션에서는 전역 Layout컴포넌트의 max-width보다 큰 값의 width를 사용해야하기 때문에 HomeLayout 컴포넌트를 따로 만들어 적용해주었습니다.
- 디자인 시안상에 존재하는 hover시 WhatWeDo 항목별 카드가 펼쳐지는 인터렉션은 제외하고 기본 UI만 구현해주었습니다.
