### PR TITLE
반응형 UX 개선을 위해 GNB에 포함된 LinkMenuList 컴포넌트를 2개로 분리

### DIFF
--- a/src/components/common/GlobalNavigationBar/GlobalNavigationBar.tsx
+++ b/src/components/common/GlobalNavigationBar/GlobalNavigationBar.tsx
@@ -1,22 +1,16 @@
 import MashUpLogo from '@/assets/svg/mashup-logo.svg';
 import { ROUTES } from '@/constants/route';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import CloseButton from '@/assets/svg/x-icon.svg';
-import { useDetectViewport } from '@/hooks';
-import { LinkMenuList } from '@/components';
+import { LinkMenuList, LinkMenuListMobile } from '@/components';
 import * as Styled from './GlobalNavigationBar.styled';
 
 const GlobalNavigationBar = () => {
-  const { viewportSize } = useDetectViewport();
-  const [isHamburgerMenuOpen, setIsHamburgerMenuOpen] = useState(viewportSize !== 'mobile');
+  const [isHamburgerMenuOpen, setIsHamburgerMenuOpen] = useState(false);
 
   const handleToggleHamburgerMenu = () => {
     setIsHamburgerMenuOpen((prevHamburgerMenuState) => !prevHamburgerMenuState);
   };
-
-  useEffect(() => {
-    setIsHamburgerMenuOpen(viewportSize !== 'mobile');
-  }, [viewportSize]);
 
   return (
     <Styled.GlobalNavigationBar>
@@ -26,7 +20,8 @@ const GlobalNavigationBar = () => {
         <Styled.MashUpPd />
       </Styled.Heading>
 
-      {isHamburgerMenuOpen && <LinkMenuList />}
+      <LinkMenuList />
+      {isHamburgerMenuOpen && <LinkMenuListMobile />}
 
       <Styled.HamburgerMenuToggleButton onClick={handleToggleHamburgerMenu}>
         {isHamburgerMenuOpen ? (

--- a/src/components/common/GlobalNavigationBar/GlobalNavigationBar.tsx
+++ b/src/components/common/GlobalNavigationBar/GlobalNavigationBar.tsx
@@ -2,7 +2,7 @@ import MashUpLogo from '@/assets/svg/mashup-logo.svg';
 import { ROUTES } from '@/constants/route';
 import { useState } from 'react';
 import CloseButton from '@/assets/svg/x-icon.svg';
-import { LinkMenuList, LinkMenuListMobile } from '@/components';
+import { LinkMenuListDesktop, LinkMenuListMobile } from '@/components';
 import * as Styled from './GlobalNavigationBar.styled';
 
 const GlobalNavigationBar = () => {
@@ -20,7 +20,7 @@ const GlobalNavigationBar = () => {
         <Styled.MashUpPd />
       </Styled.Heading>
 
-      <LinkMenuList />
+      <LinkMenuListDesktop />
       {isHamburgerMenuOpen && <LinkMenuListMobile />}
 
       <Styled.HamburgerMenuToggleButton onClick={handleToggleHamburgerMenu}>

--- a/src/components/common/LinkMenuListDesktop/LinkMenuListDesktop.styled.ts
+++ b/src/components/common/LinkMenuListDesktop/LinkMenuListDesktop.styled.ts
@@ -11,36 +11,17 @@ export const LinkMenuList = styled.ul`
     flex-flow: row nowrap;
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {
-      position: absolute;
-      top: 6.4rem;
-      left: 0;
-      flex-flow: column;
-      justify-content: center;
-      align-items: center;
-      width: 100vw;
-      height: 100vh;
-      background: ${theme.colors.light.white};
+      display: none;
     }
   `}
 `;
 
 export const Menu = styled.li`
-  ${({ theme }) => css`
-    margin-right: 2rem;
+  margin-right: 2rem;
 
-    &:last-of-type {
-      margin-right: 0;
-    }
-
-    @media (max-width: ${theme.breakPoint.media.mobile}) {
-      margin-top: 4.8rem;
-      margin-right: 0;
-
-      :first-of-type {
-        margin-top: 0;
-      }
-    }
-  `}
+  &:last-of-type {
+    margin-right: 0;
+  }
 `;
 
 interface MenuLinkProps {
@@ -62,13 +43,6 @@ export const MenuLink = styled(Link)<MenuLinkProps>`
     :active {
       border-bottom: 0.8rem solid ${active_border_color};
     }
-
-    @media (max-width: ${theme.breakPoint.media.mobile}) {
-      ${theme.fonts.bold20};
-      :active {
-        border-bottom: 1rem solid ${active_border_color};
-      }
-    }
   `}
 `;
 
@@ -89,11 +63,6 @@ export const JoinUs = styled.a<JoinUsProps>`
       & > svg > path {
         fill: ${hoverColor};
       }
-    }
-
-    @media (max-width: ${theme.breakPoint.media.mobile}) {
-      ${theme.fonts.bold20};
-      padding-bottom: 0;
     }
   `}
 `;

--- a/src/components/common/LinkMenuListDesktop/LinkMenuListDesktop.tsx
+++ b/src/components/common/LinkMenuListDesktop/LinkMenuListDesktop.tsx
@@ -1,6 +1,6 @@
 import { ROUTES } from '@/constants/route';
 import { colors } from '@/styles/themes/colors';
-import * as Styled from './LinkMenuList.styled';
+import * as Styled from './LinkMenuListDesktop.styled';
 
 const linkMenuList = [
   {

--- a/src/components/common/LinkMenuListMobile/LinkMenuListMobile.styled.ts
+++ b/src/components/common/LinkMenuListMobile/LinkMenuListMobile.styled.ts
@@ -1,0 +1,88 @@
+/* eslint-disable camelcase */
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { Link } from 'gatsby';
+import ArrowUpSideSvg from '@/assets/svg/arrow-upside.svg';
+
+export const LinkMenuList = styled.ul`
+  ${({ theme }) => css`
+    display: none;
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      position: absolute;
+      top: 6.4rem;
+      left: 0;
+      display: flex;
+      flex-flow: column;
+      justify-content: center;
+      align-items: center;
+      width: 100vw;
+      height: 100vh;
+      background: ${theme.colors.light.white};
+    }
+  `}
+`;
+
+export const Menu = styled.li`
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      margin-top: 4.8rem;
+      margin-right: 0;
+
+      :first-of-type {
+        margin-top: 0;
+      }
+    }
+  `}
+`;
+
+interface MenuLinkProps {
+  hover_color: string;
+  active_border_color: string;
+}
+
+export const MenuLink = styled(Link)<MenuLinkProps>`
+  ${({ theme, active_border_color, hover_color }) => css`
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.bold20};
+      padding: 0.8rem;
+      padding-bottom: 0;
+      color: ${theme.colors.light.gray400};
+
+      :hover {
+        color: ${hover_color};
+      }
+      :active {
+        border-bottom: 1rem solid ${active_border_color};
+      }
+    }
+  `}
+`;
+
+interface JoinUsProps {
+  hoverColor: string;
+}
+
+export const JoinUs = styled.a<JoinUsProps>`
+  ${({ theme, hoverColor }) => css`
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.bold20};
+      padding: 0.8rem;
+      padding-bottom: 0;
+      color: ${theme.colors.light.gray400};
+      cursor: pointer;
+
+      :hover {
+        color: ${hoverColor};
+
+        & > svg > path {
+          fill: ${hoverColor};
+        }
+      }
+    }
+  `}
+`;
+
+export const ArrowUpSide = styled(ArrowUpSideSvg)`
+  margin-left: 0.2rem;
+`;

--- a/src/components/common/LinkMenuListMobile/LinkMenuListMobile.tsx
+++ b/src/components/common/LinkMenuListMobile/LinkMenuListMobile.tsx
@@ -1,0 +1,55 @@
+import { ROUTES } from '@/constants/route';
+import { colors } from '@/styles/themes/colors';
+import * as Styled from './LinkMenuListMobile.styled';
+
+const linkMenuList = [
+  {
+    title: 'Article',
+    link: ROUTES.ARTICLE,
+    hoverColor: colors.light.blue300,
+    activeBorderColor: colors.light.blue100,
+  },
+  {
+    title: 'Projects',
+    link: ROUTES.PROJECTS,
+    hoverColor: colors.light.yellow300,
+    activeBorderColor: colors.light.yellow100,
+  },
+  {
+    title: 'About',
+    link: ROUTES.ABOUT,
+    hoverColor: colors.light.red300,
+    activeBorderColor: colors.light.red100,
+  },
+];
+
+const LinkMenuListMobile = () => {
+  return (
+    <Styled.LinkMenuList>
+      {linkMenuList.map(({ activeBorderColor, hoverColor, link, title }) => (
+        <Styled.Menu key={title}>
+          <Styled.MenuLink
+            to={link}
+            hover_color={hoverColor}
+            active_border_color={activeBorderColor}
+          >
+            {title}
+          </Styled.MenuLink>
+        </Styled.Menu>
+      ))}
+      <Styled.Menu>
+        <Styled.JoinUs
+          href="https://recruit.mash-up.kr"
+          target="_blank"
+          rel="noreferrer"
+          hoverColor={colors.light.blue300}
+        >
+          Join us
+          <Styled.ArrowUpSide />
+        </Styled.JoinUs>
+      </Styled.Menu>
+    </Styled.LinkMenuList>
+  );
+};
+
+export default LinkMenuListMobile;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,5 +1,5 @@
 export { default as GlobalNavigationBar } from './GlobalNavigationBar/GlobalNavigationBar';
-export { default as LinkMenuList } from './LinkMenuListDesktop/LinkMenuListDesktop';
+export { default as LinkMenuListDesktop } from './LinkMenuListDesktop/LinkMenuListDesktop';
 export { default as LinkMenuListMobile } from './LinkMenuListMobile/LinkMenuListMobile';
 export { default as Footer } from './Footer/Footer';
 export { default as ArticlePreview } from './ArticlePreview/ArticlePreview';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,5 +1,6 @@
 export { default as GlobalNavigationBar } from './GlobalNavigationBar/GlobalNavigationBar';
-export { default as LinkMenuList } from './LinkMenuList/LinkMenuList';
+export { default as LinkMenuList } from './LinkMenuListDesktop/LinkMenuListDesktop';
+export { default as LinkMenuListMobile } from './LinkMenuListMobile/LinkMenuListMobile';
 export { default as Footer } from './Footer/Footer';
 export { default as ArticlePreview } from './ArticlePreview/ArticlePreview';
 export { default as Layout } from './Layout/Layout';


### PR DESCRIPTION
## 변경사항

- window.innerWidth값을 이용하여 조건부 렌더링 하는 useDetectViewport hook을 활용하여 LinkMenuList 컴포넌트를 조건부 렌더링할때  모바일 환경에서 첫 진입시 뷰포트에 대한 상태가 mobile로 바뀔때까지 LinkMenuList가 노출되는 이슈가 있어 이것을 Desktop, Mobile 각각의 컴포넌트로 분리하고 media 쿼리를 사용하여 `display: none` 속성을 뷰포트에 따라 토글해주는 방식으로 변경하였습니다.
