### PR TITLE
hamburger button의 padding, border를 제거

### DIFF
--- a/src/components/common/GlobalNavigationBar/GlobalNavigationBar.styled.ts
+++ b/src/components/common/GlobalNavigationBar/GlobalNavigationBar.styled.ts
@@ -59,6 +59,8 @@ export const HamburgerMenuToggleButton = styled.button`
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {
       display: block;
+      padding: 0;
+      border: 0;
       background: transparent;
       cursor: pointer;
     }


### PR DESCRIPTION
## 변경사항

- MenuLinkList를 토글하는 버튼의 padding과 border가 제거되어있지 않아 발생하는 UI 이슈를 해결해주었습니다.
