### PR TITLE
아티클 상세 페이지 구현

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -12,3 +12,44 @@ exports.onCreateWebpackConfig = ({ getConfig, actions }) => {
     },
   });
 };
+
+exports.createPages = async ({ graphql, reporter, actions }) => {
+  const { createPage } = actions;
+
+  const articleTemplate = path.resolve(`src/templates/articleTemplate.tsx`);
+
+  const slugResult = await graphql(
+    `
+      query getArticleSlugs {
+        allContentfulArticles {
+          nodes {
+            slug
+          }
+        }
+      }
+    `,
+    { limit: 1000 },
+  );
+
+  if (slugResult.errors) {
+    reporter.panicOnBuild(slugResult.errors);
+    return;
+  }
+
+  if (!slugResult.data) {
+    reporter.panicOnBuild('graphql query result is empty');
+    return;
+  }
+
+  const articleSlugs = slugResult.data.allContentfulArticles.nodes;
+
+  articleSlugs.forEach(({ slug }) => {
+    createPage({
+      path: `/article/${slug}`,
+      component: articleTemplate,
+      context: {
+        slug,
+      },
+    });
+  });
+};

--- a/src/components/articleTemplate/ArticleContentSection/ArticleContentSection.tsx
+++ b/src/components/articleTemplate/ArticleContentSection/ArticleContentSection.tsx
@@ -1,0 +1,18 @@
+import { ArticleType } from '@/components/common/ArticlePreview/ArticlePreview';
+import { GatsbyImage } from 'gatsby-plugin-image';
+
+interface ArticleContentProps {
+  contentImages: ArticleType['contentImages'];
+}
+
+const ArticleContentSection = ({ contentImages }: ArticleContentProps) => {
+  return (
+    <ul>
+      {contentImages.map(({ gatsbyImageData }) => (
+        <GatsbyImage image={gatsbyImageData} alt="" />
+      ))}
+    </ul>
+  );
+};
+
+export default ArticleContentSection;

--- a/src/components/articleTemplate/ArticleDetailHeader/ArticleDetailHeader.styled.ts
+++ b/src/components/articleTemplate/ArticleDetailHeader/ArticleDetailHeader.styled.ts
@@ -1,0 +1,145 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import StartSvg from '@/assets/svg/star.svg';
+import HighlightsSvg from '@/assets/svg/highlights.svg';
+
+export const ArticleDetailHeader = styled.div`
+  ${({ theme }) => css`
+    padding: 6rem 19.2rem 6.2rem;
+    text-align: center;
+
+    @media (max-width: ${theme.breakPoint.media.tablet}) {
+      padding: 6rem 13.3rem 6.2rem;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      padding: 3rem 1.6rem 3.1rem;
+    }
+  `}
+`;
+
+export const Tag = styled.span`
+  ${({ theme }) => css`
+    ${theme.fonts.regular14};
+    padding: 0.5rem 1.3rem;
+    border-radius: 4rem;
+    background: #f4f3fb;
+    color: ${theme.colors.light.gray300};
+  `}
+`;
+
+export const Heading = styled.h2`
+  ${({ theme }) => css`
+    ${theme.fonts.semibold66};
+    position: relative;
+    margin: 3.1rem 0 5rem;
+    color: ${theme.colors.light.black};
+    text-align: center;
+    word-break: keep-all;
+
+    @media (max-width: ${theme.breakPoint.media.tablet}) {
+      ${theme.fonts.semibold40};
+      margin: 3.6rem 0 5rem;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.bold24};
+      margin: 2.1rem 0 3rem;
+    }
+  `}
+`;
+
+export const CreateAt = styled.time`
+  ${({ theme }) => css`
+    ${theme.fonts.regular20};
+    color: ${theme.colors.light.gray200};
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.regular14};
+    }
+  `}
+`;
+
+export const Highlights = styled(HighlightsSvg)`
+  ${({ theme }) =>
+    css`
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate3d(-50%, -50%, 0);
+      z-index: ${theme.zIndex.textBackground};
+      width: 43rem;
+      height: 17.6rem;
+
+      & path {
+        fill: ${theme.colors.light.blue100};
+      }
+
+      @media (max-width: ${theme.breakPoint.media.tablet}) {
+        width: 32.2rem;
+        height: 13.2rem;
+      }
+
+      @media (max-width: ${theme.breakPoint.media.mobile}) {
+        width: 22rem;
+        height: 9rem;
+      }
+    `}
+`;
+
+export const LeftStar = styled(StartSvg)`
+  ${({ theme }) => css`
+    position: absolute;
+    top: -3.5rem;
+    left: -3.8rem;
+    width: 3.8rem;
+    height: 3.8rem;
+
+    & path {
+      fill: ${theme.colors.light.blue100};
+    }
+
+    @media (max-width: ${theme.breakPoint.media.tablet}) {
+      top: -3.2rem;
+      left: -6.3rem;
+      width: 2.8rem;
+      height: 2.8rem;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      top: -1.7rem;
+      left: 0.2rem;
+      width: 1.9rem;
+      height: 1.9rem;
+    }
+  `}
+`;
+
+export const RightStar = styled(StartSvg)`
+  ${({ theme }) => css`
+    position: absolute;
+    bottom: -0.1rem;
+    right: -4rem;
+
+    width: 2.8rem;
+    height: 2.8rem;
+
+    & path {
+      fill: ${theme.colors.light.blue100};
+    }
+
+    @media (max-width: ${theme.breakPoint.media.tablet}) {
+      bottom: -2.7rem;
+      right: -6.3rem;
+      width: 2.1rem;
+      height: 2.1rem;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      bottom: -1.2rem;
+      right: -0.6rem;
+      width: 1.4rem;
+      height: 1.4rem;
+    }
+  `}
+`;

--- a/src/components/articleTemplate/ArticleDetailHeader/ArticleDetailHeader.tsx
+++ b/src/components/articleTemplate/ArticleDetailHeader/ArticleDetailHeader.tsx
@@ -1,0 +1,18 @@
+import * as Styled from './ArticleDetailHeader.styled';
+
+const ArticleDetailHeader = () => {
+  return (
+    <Styled.ArticleDetailHeader>
+      <Styled.Tag>디자인 스터디</Styled.Tag>
+      <Styled.Heading>
+        웹 디자인 스터디 이야기 - 프레이머는 어떻게 사용해야할까?
+        <Styled.Highlights />
+        <Styled.LeftStar />
+        <Styled.RightStar />
+      </Styled.Heading>
+      <Styled.CreateAt>2022. 08. 05</Styled.CreateAt>
+    </Styled.ArticleDetailHeader>
+  );
+};
+
+export default ArticleDetailHeader;

--- a/src/components/articleTemplate/ArticleDetailHeader/ArticleDetailHeader.tsx
+++ b/src/components/articleTemplate/ArticleDetailHeader/ArticleDetailHeader.tsx
@@ -1,16 +1,22 @@
+import { ArticleType } from '@/components/common/ArticlePreview/ArticlePreview';
 import * as Styled from './ArticleDetailHeader.styled';
 
-const ArticleDetailHeader = () => {
+interface ArticleDetailHeaderProps {
+  article: ArticleType;
+}
+
+const ArticleDetailHeader = ({ article }: ArticleDetailHeaderProps) => {
+  const { createdAt, tag, title } = article;
   return (
     <Styled.ArticleDetailHeader>
-      <Styled.Tag>디자인 스터디</Styled.Tag>
+      <Styled.Tag>{tag}</Styled.Tag>
       <Styled.Heading>
-        웹 디자인 스터디 이야기 - 프레이머는 어떻게 사용해야할까?
+        {title}
         <Styled.Highlights />
         <Styled.LeftStar />
         <Styled.RightStar />
       </Styled.Heading>
-      <Styled.CreateAt>2022. 08. 05</Styled.CreateAt>
+      <Styled.CreateAt>{createdAt}</Styled.CreateAt>
     </Styled.ArticleDetailHeader>
   );
 };

--- a/src/components/articleTemplate/ArticleTemplateLayout/ArticleTemplateLayout.styled.ts
+++ b/src/components/articleTemplate/ArticleTemplateLayout/ArticleTemplateLayout.styled.ts
@@ -1,0 +1,15 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const ArticleTemplateLayout = styled.div`
+  ${({ theme }) =>
+    css`
+      margin: 0 auto;
+      padding-top: 8rem;
+      max-width: 120rem;
+
+      @media (max-width: ${theme.breakPoint.media.mobile}) {
+        padding-top: 6.4rem;
+      }
+    `}
+`;

--- a/src/components/articleTemplate/ArticleTemplateLayout/ArticleTemplateLayout.tsx
+++ b/src/components/articleTemplate/ArticleTemplateLayout/ArticleTemplateLayout.tsx
@@ -1,4 +1,4 @@
-import { ArticleDetailHeader } from '@/components';
+import { ArticleDetailHeader, ArticleContentSection } from '@/components';
 import { ArticleType } from '@/components/common/ArticlePreview/ArticlePreview';
 import * as Styled from './ArticleTemplateLayout.styled';
 
@@ -10,6 +10,7 @@ const ArticleTemplateLayout = ({ article }: ArticleTemplateLayoutProps) => {
   return (
     <Styled.ArticleTemplateLayout>
       <ArticleDetailHeader article={article} />
+      <ArticleContentSection contentImages={article.contentImages} />
     </Styled.ArticleTemplateLayout>
   );
 };

--- a/src/components/articleTemplate/ArticleTemplateLayout/ArticleTemplateLayout.tsx
+++ b/src/components/articleTemplate/ArticleTemplateLayout/ArticleTemplateLayout.tsx
@@ -1,0 +1,12 @@
+import { ArticleDetailHeader } from '@/components';
+import * as Styled from './ArticleTemplateLayout.styled';
+
+const ArticleTemplateLayout = () => {
+  return (
+    <Styled.ArticleTemplateLayout>
+      <ArticleDetailHeader />
+    </Styled.ArticleTemplateLayout>
+  );
+};
+
+export default ArticleTemplateLayout;

--- a/src/components/articleTemplate/ArticleTemplateLayout/ArticleTemplateLayout.tsx
+++ b/src/components/articleTemplate/ArticleTemplateLayout/ArticleTemplateLayout.tsx
@@ -1,10 +1,15 @@
 import { ArticleDetailHeader } from '@/components';
+import { ArticleType } from '@/components/common/ArticlePreview/ArticlePreview';
 import * as Styled from './ArticleTemplateLayout.styled';
 
-const ArticleTemplateLayout = () => {
+interface ArticleTemplateLayoutProps {
+  article: ArticleType;
+}
+
+const ArticleTemplateLayout = ({ article }: ArticleTemplateLayoutProps) => {
   return (
     <Styled.ArticleTemplateLayout>
-      <ArticleDetailHeader />
+      <ArticleDetailHeader article={article} />
     </Styled.ArticleTemplateLayout>
   );
 };

--- a/src/components/articleTemplate/index.ts
+++ b/src/components/articleTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default as ArticleTemplateLayout } from './ArticleTemplateLayout/ArticleTemplateLayout';
+export { default as ArticleDetailHeader } from './ArticleDetailHeader/ArticleDetailHeader';

--- a/src/components/articleTemplate/index.ts
+++ b/src/components/articleTemplate/index.ts
@@ -1,2 +1,3 @@
 export { default as ArticleTemplateLayout } from './ArticleTemplateLayout/ArticleTemplateLayout';
 export { default as ArticleDetailHeader } from './ArticleDetailHeader/ArticleDetailHeader';
+export { default as ArticleContentSection } from './ArticleContentSection/ArticleContentSection';

--- a/src/components/common/ArticlePreview/ArticlePreview.tsx
+++ b/src/components/common/ArticlePreview/ArticlePreview.tsx
@@ -9,6 +9,7 @@ export interface ArticleType {
   tag: string;
   thumbnail: { gatsbyImageData: IGatsbyImageData };
   createdAt: string;
+  contentImages: Array<{ gatsbyImageData: IGatsbyImageData }>;
 }
 
 export interface ProjectType {

--- a/src/components/common/ArticlePreview/ArticlePreview.tsx
+++ b/src/components/common/ArticlePreview/ArticlePreview.tsx
@@ -1,3 +1,4 @@
+import { ROUTES } from '@/constants/route';
 import { IGatsbyImageData } from 'gatsby-plugin-image';
 import * as Styled from './ArticlePreview..styled';
 
@@ -13,6 +14,7 @@ export interface ArticleType {
 export interface ProjectType {
   title: string;
   slug: string;
+  description: never;
   tag: string;
   thumbnail: { gatsbyImageData: IGatsbyImageData };
   createdAt: string;
@@ -23,11 +25,13 @@ interface ArticlePreviewMdProps {
 }
 
 const ArticlePreview = ({ article }: ArticlePreviewMdProps) => {
-  const { tag, createdAt, slug, thumbnail, title } = article;
+  const { tag, createdAt, slug, thumbnail, title, description } = article;
+
+  const linkPrefix = !description ? ROUTES.PROJECTS : ROUTES.ARTICLE;
 
   return (
     <Styled.ArticlePreview>
-      <Styled.ArticleDetailLink to={slug}>
+      <Styled.ArticleDetailLink to={`${linkPrefix}/${slug}`}>
         <Styled.ContentWrapper>
           <Styled.Heading>{title}</Styled.Heading>
           <Styled.TagList>

--- a/src/components/home/ArticlePreviewLg/ArticlePreviewLg.tsx
+++ b/src/components/home/ArticlePreviewLg/ArticlePreviewLg.tsx
@@ -1,4 +1,5 @@
 import { ArticleType } from '@/components/common/ArticlePreview/ArticlePreview';
+import { ROUTES } from '@/constants/route';
 import * as Styled from './ArticlePreviewLg.styled';
 
 interface ArticlePreviewLgProps {
@@ -10,7 +11,7 @@ const ArticlePreviewLg = ({ article }: ArticlePreviewLgProps) => {
 
   return (
     <Styled.ArticlePreviewLg>
-      <Styled.ArticleDetailLink to={slug}>
+      <Styled.ArticleDetailLink to={`${ROUTES.ARTICLE}/${slug}`}>
         <Styled.ContentWrapper>
           <Styled.Heading>{title}</Styled.Heading>
           <Styled.TagList>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './common';
 export * from './home';
 export * from './article';
+export * from './articleTemplate';

--- a/src/templates/articleTemplate.tsx
+++ b/src/templates/articleTemplate.tsx
@@ -1,11 +1,36 @@
 import { ArticleTemplateLayout, Layout } from '@/components';
+import { ArticleType } from '@/components/common/ArticlePreview/ArticlePreview';
+import { graphql } from 'gatsby';
 
-const articleTemplate = () => {
+interface ArticleTemplateProps {
+  data: {
+    contentfulArticles: ArticleType;
+  };
+}
+
+const ArticleTemplate = ({ data }: ArticleTemplateProps) => {
+  const { contentfulArticles } = data;
+
   return (
     <Layout>
-      <ArticleTemplateLayout />
+      <ArticleTemplateLayout article={contentfulArticles} />
     </Layout>
   );
 };
 
-export default articleTemplate;
+export default ArticleTemplate;
+
+export const queryMarkdownDataBySlug = graphql`
+  query getArticleDetail($slug: String) {
+    contentfulArticles(slug: { eq: $slug }) {
+      title
+      slug
+      description
+      tag
+      thumbnail {
+        gatsbyImageData
+      }
+      createdAt(formatString: "YYYY. MM. DD")
+    }
+  }
+`;

--- a/src/templates/articleTemplate.tsx
+++ b/src/templates/articleTemplate.tsx
@@ -30,6 +30,9 @@ export const queryMarkdownDataBySlug = graphql`
       thumbnail {
         gatsbyImageData
       }
+      contentImages {
+        gatsbyImageData
+      }
       createdAt(formatString: "YYYY. MM. DD")
     }
   }

--- a/src/templates/articleTemplate.tsx
+++ b/src/templates/articleTemplate.tsx
@@ -1,5 +1,11 @@
+import { ArticleTemplateLayout, Layout } from '@/components';
+
 const articleTemplate = () => {
-  return <div>articleTemplate</div>;
+  return (
+    <Layout>
+      <ArticleTemplateLayout />
+    </Layout>
+  );
 };
 
 export default articleTemplate;

--- a/src/templates/articleTemplate.tsx
+++ b/src/templates/articleTemplate.tsx
@@ -1,0 +1,5 @@
+const articleTemplate = () => {
+  return <div>articleTemplate</div>;
+};
+
+export default articleTemplate;


### PR DESCRIPTION
## 변경사항

- 아티클의 고유한 slug를 기반으로 article 상세페이지를 동적으로 생성합니다.
- 각각의 아티클에 있는 title, tag, createAt, contentImages등을 graphql로 쿼리하여 받아온 후 정해진 UI로 화면에 뿌려줍니다.
