### PR TITLE
UI 디테일 작업

### DIFF
--- a/src/components/common/ArticlePreview/ArticlePreview..styled.ts
+++ b/src/components/common/ArticlePreview/ArticlePreview..styled.ts
@@ -11,7 +11,7 @@ export const ArticlePreview = styled.article`
 export const ArticleDetailLink = styled(Link)`
   display: flex;
   flex-flow: column nowrap;
-  max-height: 100%;
+  height: 100%;
 `;
 
 export const ContentWrapper = styled.div`
@@ -39,7 +39,7 @@ export const Heading = styled.h3`
 
 export const Thumbnail = styled(GatsbyImage)`
   border-radius: 0 0 1.6rem 1.6rem;
-  flex-basis: 100vh;
+  height: 100%;
   z-index: -1;
 `;
 

--- a/src/components/common/ArticlePreview/ArticlePreview..styled.ts
+++ b/src/components/common/ArticlePreview/ArticlePreview..styled.ts
@@ -40,6 +40,7 @@ export const Heading = styled.h3`
 export const Thumbnail = styled(GatsbyImage)`
   border-radius: 0 0 1.6rem 1.6rem;
   flex-basis: 100vh;
+  z-index: -1;
 `;
 
 export const CreateAt = styled.time`

--- a/src/components/common/ArticlePreview/ArticlePreview..styled.ts
+++ b/src/components/common/ArticlePreview/ArticlePreview..styled.ts
@@ -3,9 +3,35 @@ import styled from '@emotion/styled';
 import { Link } from 'gatsby';
 import { GatsbyImage } from 'gatsby-plugin-image';
 
-export const ArticlePreview = styled.article`
+export const ArticlePreviewWrapper = styled.article`
+  position: relative;
+`;
+
+export const ArticlePreviewBackground = styled.div`
+  ${({ theme }) => css`
+    position: absolute;
+    top: 0;
+    left: 0;
+    border-radius: 1.6rem;
+    background: #dad9e9;
+    width: 100%;
+    height: 100%;
+    z-index: ${theme.zIndex.textBackground};
+  `}
+`;
+
+export const ArticlePreview = styled.div`
+  position: relative;
   box-shadow: 0rem 0.4rem 1.2rem rgba(46, 44, 44, 0.25);
   border-radius: 1.6rem;
+  transition: 0.3s;
+  height: 100%;
+
+  @media (hover: hover) {
+    &:hover {
+      transform: translate3d(-1.8rem, -1.8rem, 0);
+    }
+  }
 `;
 
 export const ArticleDetailLink = styled(Link)`
@@ -20,6 +46,8 @@ export const ContentWrapper = styled.div`
     flex-flow: column nowrap;
     gap: 1.6rem;
     padding: 1.6rem 2.4rem 1.7rem 2.4rem;
+    background: ${theme.colors.light.white};
+    border-radius: 1.6rem 1.6rem 0 0;
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {
       padding: 1.6rem 2.4rem 1.6rem 2.4rem;
@@ -38,9 +66,12 @@ export const Heading = styled.h3`
 `;
 
 export const Thumbnail = styled(GatsbyImage)`
-  border-radius: 0 0 1.6rem 1.6rem;
-  height: 100%;
-  z-index: -1;
+  ${({ theme }) => css`
+    border-radius: 0 0 1.6rem 1.6rem;
+    height: 100%;
+    background: ${theme.colors.light.white};
+    z-index: -1;
+  `}
 `;
 
 export const CreateAt = styled.time`

--- a/src/components/common/ArticlePreview/ArticlePreview.tsx
+++ b/src/components/common/ArticlePreview/ArticlePreview.tsx
@@ -31,19 +31,22 @@ const ArticlePreview = ({ article }: ArticlePreviewMdProps) => {
   const linkPrefix = !description ? ROUTES.PROJECTS : ROUTES.ARTICLE;
 
   return (
-    <Styled.ArticlePreview>
-      <Styled.ArticleDetailLink to={`${linkPrefix}/${slug}`}>
-        <Styled.ContentWrapper>
-          <Styled.Heading>{title}</Styled.Heading>
-          <Styled.TagList>
-            <Styled.Latest>최신</Styled.Latest>
-            <Styled.Tag>{tag}</Styled.Tag>
-          </Styled.TagList>
-          <Styled.CreateAt>{createdAt}</Styled.CreateAt>
-        </Styled.ContentWrapper>
-        <Styled.Thumbnail image={thumbnail.gatsbyImageData} alt="" />
-      </Styled.ArticleDetailLink>
-    </Styled.ArticlePreview>
+    <Styled.ArticlePreviewWrapper>
+      <Styled.ArticlePreview>
+        <Styled.ArticleDetailLink to={`${linkPrefix}/${slug}`}>
+          <Styled.ContentWrapper>
+            <Styled.Heading>{title}</Styled.Heading>
+            <Styled.TagList>
+              <Styled.Latest>최신</Styled.Latest>
+              <Styled.Tag>{tag}</Styled.Tag>
+            </Styled.TagList>
+            <Styled.CreateAt>{createdAt}</Styled.CreateAt>
+          </Styled.ContentWrapper>
+          <Styled.Thumbnail image={thumbnail.gatsbyImageData} alt="" />
+        </Styled.ArticleDetailLink>
+      </Styled.ArticlePreview>
+      <Styled.ArticlePreviewBackground />
+    </Styled.ArticlePreviewWrapper>
   );
 };
 

--- a/src/components/common/GlobalNavigationBar/GlobalNavigationBar.styled.ts
+++ b/src/components/common/GlobalNavigationBar/GlobalNavigationBar.styled.ts
@@ -3,8 +3,12 @@ import styled from '@emotion/styled';
 import MashUpPdSvg from '@/assets/svg/mashup-pd.svg';
 import { Link } from 'gatsby';
 
-export const GlobalNavigationBar = styled.nav`
-  ${({ theme }) => css`
+interface GlobalNavigationBarProps {
+  isScrollTop: boolean;
+}
+
+export const GlobalNavigationBar = styled.nav<GlobalNavigationBarProps>`
+  ${({ theme, isScrollTop }) => css`
     position: fixed;
     top: 0;
     left: 50%;
@@ -17,6 +21,8 @@ export const GlobalNavigationBar = styled.nav`
     height: 8rem;
     width: 100%;
     max-width: 120rem;
+    transition: 0.2s;
+    background: ${isScrollTop ? 'transparent' : theme.colors.light.white};
     z-index: ${theme.zIndex.gnb};
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {
@@ -25,9 +31,17 @@ export const GlobalNavigationBar = styled.nav`
   `}
 `;
 
-export const Heading = styled(Link)`
-  display: flex;
-  align-items: center;
+interface HeadingProps {
+  isScrollTop: boolean;
+}
+
+export const Heading = styled(Link)<HeadingProps>`
+  ${({ isScrollTop }) => css`
+    display: flex;
+    align-items: center;
+    transition: 0.2s;
+    opacity: ${isScrollTop ? 0 : 1};
+  `}
 `;
 
 export const MashUpPd = styled(MashUpPdSvg)`

--- a/src/components/common/GlobalNavigationBar/GlobalNavigationBar.styled.ts
+++ b/src/components/common/GlobalNavigationBar/GlobalNavigationBar.styled.ts
@@ -5,10 +5,11 @@ import { Link } from 'gatsby';
 
 interface GlobalNavigationBarProps {
   isScrollTop: boolean;
+  isHamburgerMenuOpen: boolean;
 }
 
 export const GlobalNavigationBar = styled.nav<GlobalNavigationBarProps>`
-  ${({ theme, isScrollTop }) => css`
+  ${({ theme, isScrollTop, isHamburgerMenuOpen }) => css`
     position: fixed;
     top: 0;
     left: 50%;
@@ -22,7 +23,7 @@ export const GlobalNavigationBar = styled.nav<GlobalNavigationBarProps>`
     width: 100%;
     max-width: 120rem;
     transition: 0.2s;
-    background: ${isScrollTop ? 'transparent' : theme.colors.light.white};
+    background: ${!isHamburgerMenuOpen && isScrollTop ? 'transparent' : theme.colors.light.white};
     z-index: ${theme.zIndex.gnb};
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {

--- a/src/components/common/GlobalNavigationBar/GlobalNavigationBar.tsx
+++ b/src/components/common/GlobalNavigationBar/GlobalNavigationBar.tsx
@@ -3,6 +3,7 @@ import { ROUTES } from '@/constants/route';
 import { useState } from 'react';
 import CloseButton from '@/assets/svg/x-icon.svg';
 import { LinkMenuListDesktop, LinkMenuListMobile } from '@/components';
+import { useScrollTop } from '@/hooks';
 import * as Styled from './GlobalNavigationBar.styled';
 
 const GlobalNavigationBar = () => {
@@ -12,9 +13,11 @@ const GlobalNavigationBar = () => {
     setIsHamburgerMenuOpen((prevHamburgerMenuState) => !prevHamburgerMenuState);
   };
 
+  const { isScrollTop } = useScrollTop();
+
   return (
-    <Styled.GlobalNavigationBar>
-      <Styled.Heading to={ROUTES.HOME}>
+    <Styled.GlobalNavigationBar isScrollTop={isScrollTop}>
+      <Styled.Heading to={ROUTES.HOME} isScrollTop={isScrollTop}>
         <MashUpLogo />
         <Styled.HeadingText>Mash Up Design</Styled.HeadingText>
         <Styled.MashUpPd />

--- a/src/components/common/GlobalNavigationBar/GlobalNavigationBar.tsx
+++ b/src/components/common/GlobalNavigationBar/GlobalNavigationBar.tsx
@@ -16,7 +16,7 @@ const GlobalNavigationBar = () => {
   const { isScrollTop } = useScrollTop();
 
   return (
-    <Styled.GlobalNavigationBar isScrollTop={isScrollTop}>
+    <Styled.GlobalNavigationBar isScrollTop={isScrollTop} isHamburgerMenuOpen={isHamburgerMenuOpen}>
       <Styled.Heading to={ROUTES.HOME} isScrollTop={isScrollTop}>
         <MashUpLogo />
         <Styled.HeadingText>Mash Up Design</Styled.HeadingText>

--- a/src/components/common/LinkMenuListDesktop/LinkMenuListDesktop.styled.ts
+++ b/src/components/common/LinkMenuListDesktop/LinkMenuListDesktop.styled.ts
@@ -36,8 +36,10 @@ export const MenuLink = styled(Link)<MenuLinkProps>`
     color: ${theme.colors.light.gray400};
     padding-bottom: 0;
 
-    :hover {
-      color: ${hover_color};
+    @media (hover: hover) {
+      :hover {
+        color: ${hover_color};
+      }
     }
 
     :active {
@@ -57,8 +59,10 @@ export const JoinUs = styled.a<JoinUsProps>`
     color: ${theme.colors.light.gray400};
     cursor: pointer;
 
-    :hover {
-      color: ${hoverColor};
+    @media (hover: hover) {
+      :hover {
+        color: ${hoverColor};
+      }
 
       & > svg > path {
         fill: ${hoverColor};

--- a/src/components/common/LinkMenuListMobile/LinkMenuListMobile.styled.ts
+++ b/src/components/common/LinkMenuListMobile/LinkMenuListMobile.styled.ts
@@ -49,9 +49,12 @@ export const MenuLink = styled(Link)<MenuLinkProps>`
       padding-bottom: 0;
       color: ${theme.colors.light.gray400};
 
-      :hover {
-        color: ${hover_color};
+      @media (hover: hover) {
+        :hover {
+          color: ${hover_color};
+        }
       }
+
       :active {
         border-bottom: 1rem solid ${active_border_color};
       }
@@ -72,11 +75,13 @@ export const JoinUs = styled.a<JoinUsProps>`
       color: ${theme.colors.light.gray400};
       cursor: pointer;
 
-      :hover {
-        color: ${hoverColor};
+      @media (hover: hover) {
+        :hover {
+          color: ${hoverColor};
 
-        & > svg > path {
-          fill: ${hoverColor};
+          & > svg > path {
+            fill: ${hoverColor};
+          }
         }
       }
     }

--- a/src/components/home/ArticlePreviewLg/ArticlePreviewLg.styled.ts
+++ b/src/components/home/ArticlePreviewLg/ArticlePreviewLg.styled.ts
@@ -55,12 +55,13 @@ export const Heading = styled.h3`
 
 export const Thumbnail = styled(GatsbyImage)`
   ${({ theme }) => css`
-    min-width: 57.2rem;
+    width: 57.2rem;
+    height: 41.5rem;
     order: 1;
 
     @media (max-width: ${theme.breakPoint.media.tablet}) {
-      min-width: 100%;
-      min-height: 51.23vw;
+      width: 100%;
+      height: 51.23vw;
     }
   `}
 `;

--- a/src/components/home/ArticleSection/ArticleSection.styled.ts
+++ b/src/components/home/ArticleSection/ArticleSection.styled.ts
@@ -6,7 +6,8 @@ export const ArticleSection = styled.section`
     display: grid;
     width: 100%;
     grid-template-columns: calc(50% - 1.5rem) calc(50% - 1.5rem);
-    grid-template-rows: auto 40.4rem;
+    grid-template-rows: auto;
+    grid-auto-rows: 40.4rem;
     column-gap: 3rem;
     row-gap: 3.6rem;
     margin: 0 auto;
@@ -24,13 +25,16 @@ export const ArticleSection = styled.section`
     }
 
     @media (max-width: ${theme.breakPoint.media.tablet}) {
-      grid-template-rows: auto 53.1vw;
+      grid-template-rows: auto;
+      grid-auto-rows: 53.1rem;
+
       column-gap: 3.4rem;
     }
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {
       grid-template-columns: 100%;
-      grid-template-rows: 119.45vw 119.45vw;
+      grid-template-rows: 119.45vw;
+      grid-auto-rows: 119.45vw;
 
       & > article {
         &:first-of-type {

--- a/src/components/home/ArticleSection/ArticleSection.tsx
+++ b/src/components/home/ArticleSection/ArticleSection.tsx
@@ -11,11 +11,19 @@ interface ArticleSectionProps {
 
 const ArticleSection = ({ allContentfulArticles }: ArticleSectionProps) => {
   const { viewportSize } = useDetectViewport();
+
+  const SHOW_ARTICLE_COUNT = viewportSize === 'mobile' ? 2 : 3;
+
+  const slicedArticles = allContentfulArticles.nodes.slice(0, SHOW_ARTICLE_COUNT);
   return (
     <Styled.ArticleSection>
-      {viewportSize !== 'mobile' && <ArticlePreviewLg article={allContentfulArticles.nodes[0]} />}
-      <ArticlePreview article={allContentfulArticles.nodes[0]} />
-      <ArticlePreview article={allContentfulArticles.nodes[1]} />
+      {slicedArticles.map((article, index) =>
+        index === 0 && viewportSize !== 'mobile' ? (
+          <ArticlePreviewLg article={article} />
+        ) : (
+          <ArticlePreview article={article} />
+        ),
+      )}
     </Styled.ArticleSection>
   );
 };

--- a/src/components/home/Header/Header.styled.ts
+++ b/src/components/home/Header/Header.styled.ts
@@ -163,10 +163,12 @@ export const ExternalLink = styled.a`
         margin-bottom: 0.3rem;
       }
 
-      &:hover {
-        & > div {
-          background: ${theme.colors.light.yellow200};
-          opacity: 0.6;
+      @media (hover: hover) {
+        &:hover {
+          & > div {
+            background: ${theme.colors.light.yellow200};
+            opacity: 0.6;
+          }
         }
       }
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useDetectViewport } from './useDetectViewport';
+export { default as useScrollTop } from './useScrollTop';

--- a/src/hooks/useScrollTop.ts
+++ b/src/hooks/useScrollTop.ts
@@ -1,0 +1,32 @@
+import throttle from 'lodash-es/throttle';
+import { useEffect, useState } from 'react';
+
+const useScrollTop = () => {
+  const [isScrollTop, setIsScrollTop] = useState(true);
+
+  useEffect(() => {
+    const handleDetectIsScrollTop = throttle(() => {
+      const { scrollY } = window;
+
+      if (scrollY !== 0) {
+        if (!isScrollTop) return;
+
+        setIsScrollTop(false);
+        return;
+      }
+
+      setIsScrollTop(true);
+    }, 200);
+
+    window.addEventListener('scroll', handleDetectIsScrollTop);
+
+    return () => {
+      window.removeEventListener('scroll', handleDetectIsScrollTop);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { isScrollTop };
+};
+
+export default useScrollTop;

--- a/src/pages/article.tsx
+++ b/src/pages/article.tsx
@@ -29,7 +29,7 @@ export default Article;
 
 export const query = graphql`
   query getArticlePageData {
-    allContentfulArticles {
+    allContentfulArticles(sort: { fields: createdAt, order: DESC }) {
       nodes {
         title
         slug

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -40,7 +40,7 @@ export default IndexPage;
 
 export const query = graphql`
   query getIndexPageData {
-    allContentfulArticles {
+    allContentfulArticles(sort: { fields: createdAt, order: DESC }) {
       nodes {
         title
         slug
@@ -52,7 +52,7 @@ export const query = graphql`
         createdAt(formatString: "MMMM DD, YYYY")
       }
     }
-    allContentfulProject {
+    allContentfulProject(sort: { fields: createdAt, order: DESC }) {
       nodes {
         title
         slug


### PR DESCRIPTION
## 변경사항

- ArticlePreviewLg내부 thumbnail의 width, height값을 외부 컨테이너에 더 유연하게 변경해줍니다.
- Scroll이 top인지에 대한 값을 반환하는 hook을 만들어 scroll top일때 GNB자체와 GNB의 Heading을 `opacity: 0 <-> 1` 로 토글 처리 해줍니다.
- safari 브라우저에서 ArticlePreview내부 Thumbnail의 z-index가 더 높아 border-radius가 적용되지 않는 이슈가 있어 Thumbnail의 z-index를 -1로 변경해주었습니다.
- graphql로 요청하여 받아오는 데이터들을 생성일을 기준으로 내침차순으로 쿼리하도록 수정하였습니다.
