### PR TITLE
Article 페이지에서 태그에 따른 필터링 기능 추가

### DIFF
--- a/src/components/article/ArticleList/ArticleList.tsx
+++ b/src/components/article/ArticleList/ArticleList.tsx
@@ -2,14 +2,22 @@ import { ArticleType } from '@/components/common/ArticlePreview/ArticlePreview';
 import { ArticlePreview } from '@/components';
 import * as Styled from './ArticleList.styled';
 
+export const INITIAL_FILTER_BY_TAG = '전체';
+
 interface ArticleListProps {
   articles: ArticleType[];
+  currentFilterByTag: string;
 }
 
-const ArticleList = ({ articles }: ArticleListProps) => {
+const ArticleList = ({ articles, currentFilterByTag }: ArticleListProps) => {
+  const filteredArticles =
+    currentFilterByTag === INITIAL_FILTER_BY_TAG
+      ? articles
+      : articles.filter(({ tag }) => tag === currentFilterByTag);
+
   return (
     <Styled.ArticleList>
-      {articles.map((article) => (
+      {filteredArticles.map((article) => (
         <ArticlePreview article={article} key={article.slug} />
       ))}
     </Styled.ArticleList>

--- a/src/components/article/ArticleList/ArticleList.tsx
+++ b/src/components/article/ArticleList/ArticleList.tsx
@@ -1,4 +1,4 @@
-import { ArticleType } from '@/components/common/ArticlePreview/ArticlePreview';
+import { ArticleType, LATEST_COUNT } from '@/components/common/ArticlePreview/ArticlePreview';
 import { ArticlePreview } from '@/components';
 import * as Styled from './ArticleList.styled';
 
@@ -10,10 +10,15 @@ interface ArticleListProps {
 }
 
 const ArticleList = ({ articles, currentFilterByTag }: ArticleListProps) => {
+  const distinguishedLatestArticles = articles.map((article, index) => ({
+    ...article,
+    isLatest: index < LATEST_COUNT,
+  }));
+
   const filteredArticles =
     currentFilterByTag === INITIAL_FILTER_BY_TAG
-      ? articles
-      : articles.filter(({ tag }) => tag === currentFilterByTag);
+      ? distinguishedLatestArticles
+      : distinguishedLatestArticles.filter(({ tag }) => tag === currentFilterByTag);
 
   return (
     <Styled.ArticleList>

--- a/src/components/article/ArticlesSection/ArticlesSection.tsx
+++ b/src/components/article/ArticlesSection/ArticlesSection.tsx
@@ -1,5 +1,7 @@
 import { FilterWithTag, ArticleList } from '@/components';
 import { ArticleType } from '@/components/common/ArticlePreview/ArticlePreview';
+import { useState } from 'react';
+import { INITIAL_FILTER_BY_TAG } from '@/components/article/ArticleList/ArticleList';
 import * as Styled from './ArticlesSection.styled';
 
 interface ArticlesSectionProps {
@@ -8,12 +10,18 @@ interface ArticlesSectionProps {
 
 const ArticlesSection = ({ articles }: ArticlesSectionProps) => {
   const tagList = articles.map(({ tag }) => tag);
-  const deDuplicatedTagList = ['전체', ...new Set(tagList)];
+  const deDuplicatedTagList = [...new Set([INITIAL_FILTER_BY_TAG, ...tagList])];
+
+  const [currentFilterByTag, setCurrentFilterByTag] = useState(INITIAL_FILTER_BY_TAG);
 
   return (
     <Styled.ArticlesSection>
-      <FilterWithTag tagList={deDuplicatedTagList} />
-      <ArticleList articles={articles} />
+      <FilterWithTag
+        tagList={deDuplicatedTagList}
+        currentFilterByTag={currentFilterByTag}
+        setCurrentFilterByTag={setCurrentFilterByTag}
+      />
+      <ArticleList articles={articles} currentFilterByTag={currentFilterByTag} />
     </Styled.ArticlesSection>
   );
 };

--- a/src/components/article/FilterWithTag/FilterWithTag.styled.ts
+++ b/src/components/article/FilterWithTag/FilterWithTag.styled.ts
@@ -16,13 +16,17 @@ export const FilterWithTag = styled.ul`
   }
 `;
 
-export const Tag = styled.button`
-  ${({ theme }) => css`
+interface TagProps {
+  isSelected: boolean;
+}
+
+export const Tag = styled.button<TagProps>`
+  ${({ theme, isSelected }) => css`
     ${theme.fonts.bold14};
     padding: 0.8rem 1.4rem;
     border: 0;
     border-radius: 4rem;
-    background: ${theme.colors.light.gray50};
-    color: ${theme.colors.light.gray200};
+    background: ${isSelected ? theme.colors.light.blue200 : theme.colors.light.gray50};
+    color: ${isSelected ? theme.colors.light.white : theme.colors.light.gray200};
   `}
 `;

--- a/src/components/article/FilterWithTag/FilterWithTag.tsx
+++ b/src/components/article/FilterWithTag/FilterWithTag.tsx
@@ -1,14 +1,31 @@
+import { Dispatch, SetStateAction } from 'react';
 import * as Styled from './FilterWithTag.styled';
 
 interface FilterWithTagProps {
   tagList: string[];
+  currentFilterByTag: string;
+  setCurrentFilterByTag: Dispatch<SetStateAction<string>>;
 }
 
-const FilterWithTag = ({ tagList }: FilterWithTagProps) => {
+const FilterWithTag = ({
+  tagList,
+  currentFilterByTag,
+  setCurrentFilterByTag,
+}: FilterWithTagProps) => {
+  const handleChangeCurrentFilterByTag = (tag: string) => {
+    setCurrentFilterByTag(tag);
+  };
+
   return (
     <Styled.FilterWithTag>
       {tagList.map((tag) => (
-        <Styled.Tag key={tag}>{tag}</Styled.Tag>
+        <Styled.Tag
+          isSelected={tag === currentFilterByTag}
+          onClick={() => handleChangeCurrentFilterByTag(tag)}
+          key={tag}
+        >
+          {tag}
+        </Styled.Tag>
       ))}
     </Styled.FilterWithTag>
   );

--- a/src/components/common/ArticlePreview/ArticlePreview.tsx
+++ b/src/components/common/ArticlePreview/ArticlePreview.tsx
@@ -2,6 +2,12 @@ import { ROUTES } from '@/constants/route';
 import { IGatsbyImageData } from 'gatsby-plugin-image';
 import * as Styled from './ArticlePreview..styled';
 
+export const LATEST_COUNT = 3;
+
+export interface IsLatestType {
+  isLatest: boolean;
+}
+
 export interface ArticleType {
   title: string;
   slug: string;
@@ -22,11 +28,11 @@ export interface ProjectType {
 }
 
 interface ArticlePreviewMdProps {
-  article: ArticleType | ProjectType;
+  article: (ArticleType & IsLatestType) | (ProjectType & IsLatestType);
 }
 
 const ArticlePreview = ({ article }: ArticlePreviewMdProps) => {
-  const { tag, createdAt, slug, thumbnail, title, description } = article;
+  const { tag, createdAt, slug, thumbnail, title, description, isLatest } = article;
 
   const linkPrefix = !description ? ROUTES.PROJECTS : ROUTES.ARTICLE;
 
@@ -37,7 +43,7 @@ const ArticlePreview = ({ article }: ArticlePreviewMdProps) => {
           <Styled.ContentWrapper>
             <Styled.Heading>{title}</Styled.Heading>
             <Styled.TagList>
-              <Styled.Latest>최신</Styled.Latest>
+              {isLatest && <Styled.Latest>최신</Styled.Latest>}
               <Styled.Tag>{tag}</Styled.Tag>
             </Styled.TagList>
             <Styled.CreateAt>{createdAt}</Styled.CreateAt>

--- a/src/components/common/LinkMenuListDesktop/LinkMenuListDesktop.styled.ts
+++ b/src/components/common/LinkMenuListDesktop/LinkMenuListDesktop.styled.ts
@@ -62,10 +62,10 @@ export const JoinUs = styled.a<JoinUsProps>`
     @media (hover: hover) {
       :hover {
         color: ${hoverColor};
-      }
 
-      & > svg > path {
-        fill: ${hoverColor};
+        & > svg > path {
+          fill: ${hoverColor};
+        }
       }
     }
   `}

--- a/src/components/home/ArticleSection/ArticleSection.tsx
+++ b/src/components/home/ArticleSection/ArticleSection.tsx
@@ -1,6 +1,6 @@
 import { ArticlePreview, ArticlePreviewLg } from '@/components';
 import { useDetectViewport } from '@/hooks';
-import { ArticleType } from '@/components/common/ArticlePreview/ArticlePreview';
+import { ArticleType, LATEST_COUNT } from '@/components/common/ArticlePreview/ArticlePreview';
 import * as Styled from './ArticleSection.styled';
 
 interface ArticleSectionProps {
@@ -15,9 +15,14 @@ const ArticleSection = ({ allContentfulArticles }: ArticleSectionProps) => {
   const SHOW_ARTICLE_COUNT = viewportSize === 'mobile' ? 2 : 3;
 
   const slicedArticles = allContentfulArticles.nodes.slice(0, SHOW_ARTICLE_COUNT);
+
+  const distinguishedLatestArticles = slicedArticles.map((article, index) => ({
+    ...article,
+    isLatest: index < LATEST_COUNT,
+  }));
   return (
     <Styled.ArticleSection>
-      {slicedArticles.map((article, index) =>
+      {distinguishedLatestArticles.map((article, index) =>
         index === 0 && viewportSize !== 'mobile' ? (
           <ArticlePreviewLg article={article} key={article.slug} />
         ) : (

--- a/src/components/home/ProjectSection/ProjectSection.tsx
+++ b/src/components/home/ProjectSection/ProjectSection.tsx
@@ -1,5 +1,5 @@
 import { ArticlePreview } from '@/components/common';
-import { ProjectType } from '@/components/common/ArticlePreview/ArticlePreview';
+import { LATEST_COUNT, ProjectType } from '@/components/common/ArticlePreview/ArticlePreview';
 import { ROUTES } from '@/constants/route';
 import { ViewPort } from '@/constants/viewport';
 import { useDetectViewport } from '@/hooks';
@@ -23,11 +23,16 @@ const ProjectSection = ({ allContentfulProject }: ProjectSectionProps) => {
   const numberOfProjects = getNumberOfProjectsPerViewport(viewportSize);
   const projectList = nodes.slice(0, numberOfProjects);
 
+  const distinguishedLatestProjects = projectList.map((article, index) => ({
+    ...article,
+    isLatest: index < LATEST_COUNT,
+  }));
+
   return (
     <Styled.ProjectSection>
       <Styled.Heading>Featured project</Styled.Heading>
       <Styled.ProjectList>
-        {projectList.map((project) => (
+        {distinguishedLatestProjects.map((project) => (
           <ArticlePreview article={project} key={project.slug} />
         ))}
       </Styled.ProjectList>


### PR DESCRIPTION
## 변경사항

- Article에 달린 tag들의 리스트를 보여주고 특정 태그를 눌렀을때 해당 태그로 지정되어 있는 article만 보여지는 필터링 기능 추가
- 현재 CreateAt 기준으로 내림차순되어 데이터를 받고 있기 때문에 0, 1, 2번 index에 존재하는 article에만 최신 태그가 붙게끔 구현
- GNB 내부 Join us의 hover시 컬러가 hover가 안되었을때 적용되고 있어서 이를 수정
