### PR TITLE
프로젝트 페이지 및 프로젝트 상세 페이지 UI 구현

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { createArticlePage, createProjectPage } = require('./src/gatsby/createPages');
 
 exports.onCreateWebpackConfig = ({ getConfig, actions }) => {
   const output = getConfig().output || {};
@@ -13,43 +14,6 @@ exports.onCreateWebpackConfig = ({ getConfig, actions }) => {
   });
 };
 
-exports.createPages = async ({ graphql, reporter, actions }) => {
-  const { createPage } = actions;
-
-  const articleTemplate = path.resolve(`src/templates/articleTemplate.tsx`);
-
-  const slugResult = await graphql(
-    `
-      query getArticleSlugs {
-        allContentfulArticles {
-          nodes {
-            slug
-          }
-        }
-      }
-    `,
-    { limit: 1000 },
-  );
-
-  if (slugResult.errors) {
-    reporter.panicOnBuild(slugResult.errors);
-    return;
-  }
-
-  if (!slugResult.data) {
-    reporter.panicOnBuild('graphql query result is empty');
-    return;
-  }
-
-  const articleSlugs = slugResult.data.allContentfulArticles.nodes;
-
-  articleSlugs.forEach(({ slug }) => {
-    createPage({
-      path: `/article/${slug}`,
-      component: articleTemplate,
-      context: {
-        slug,
-      },
-    });
-  });
+exports.createPages = async (params) => {
+  await Promise.all([createArticlePage(params), createProjectPage(params)]);
 };

--- a/src/components/common/ArticlePreview/ArticlePreview.tsx
+++ b/src/components/common/ArticlePreview/ArticlePreview.tsx
@@ -25,6 +25,7 @@ export interface ProjectType {
   tag: string;
   thumbnail: { gatsbyImageData: IGatsbyImageData };
   createdAt: string;
+  contentImages: Array<{ gatsbyImageData: IGatsbyImageData }>;
 }
 
 interface ArticlePreviewMdProps {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,3 +2,4 @@ export * from './common';
 export * from './home';
 export * from './article';
 export * from './articleTemplate';
+export * from './projects';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,3 +3,4 @@ export * from './home';
 export * from './article';
 export * from './articleTemplate';
 export * from './projects';
+export * from './projectTemplate';

--- a/src/components/projectTemplate/ProjectContentSection/ProjectContentSection.tsx
+++ b/src/components/projectTemplate/ProjectContentSection/ProjectContentSection.tsx
@@ -1,0 +1,18 @@
+import { ProjectType } from '@/components/common/ArticlePreview/ArticlePreview';
+import { GatsbyImage } from 'gatsby-plugin-image';
+
+interface ProjectContentSectionProps {
+  contentImages: ProjectType['contentImages'];
+}
+
+const ProjectContentSection = ({ contentImages }: ProjectContentSectionProps) => {
+  return (
+    <ul>
+      {contentImages.map(({ gatsbyImageData }) => (
+        <GatsbyImage image={gatsbyImageData} alt="" />
+      ))}
+    </ul>
+  );
+};
+
+export default ProjectContentSection;

--- a/src/components/projectTemplate/ProjectTemplateLayout/ProjectTemplateLayout.styled.ts
+++ b/src/components/projectTemplate/ProjectTemplateLayout/ProjectTemplateLayout.styled.ts
@@ -1,0 +1,15 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const ProjectTemplateLayout = styled.div`
+  ${({ theme }) =>
+    css`
+      margin: 0 auto;
+      padding-top: 8rem;
+      max-width: 120rem;
+
+      @media (max-width: ${theme.breakPoint.media.mobile}) {
+        padding-top: 6.4rem;
+      }
+    `}
+`;

--- a/src/components/projectTemplate/ProjectTemplateLayout/ProjectTemplateLayout.tsx
+++ b/src/components/projectTemplate/ProjectTemplateLayout/ProjectTemplateLayout.tsx
@@ -1,0 +1,17 @@
+import { ProjectContentSection } from '@/components';
+import { ProjectType } from '@/components/common/ArticlePreview/ArticlePreview';
+import * as Styled from './ProjectTemplateLayout.styled';
+
+interface AProjectTemplateLayoutProps {
+  project: ProjectType;
+}
+
+const ProjectTemplateLayout = ({ project }: AProjectTemplateLayoutProps) => {
+  return (
+    <Styled.ProjectTemplateLayout>
+      <ProjectContentSection contentImages={project.contentImages} />
+    </Styled.ProjectTemplateLayout>
+  );
+};
+
+export default ProjectTemplateLayout;

--- a/src/components/projectTemplate/index.ts
+++ b/src/components/projectTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default as ProjectTemplateLayout } from './ProjectTemplateLayout/ProjectTemplateLayout';
+export { default as ProjectContentSection } from './ProjectContentSection/ProjectContentSection';

--- a/src/components/projects/ProjectList/ProjectList.styled.ts
+++ b/src/components/projects/ProjectList/ProjectList.styled.ts
@@ -1,0 +1,25 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const ProjectList = styled.ul`
+  ${({ theme }) => css`
+    display: grid;
+    grid-template-columns: repeat(3, 36.4rem);
+    grid-auto-rows: 43rem;
+    column-gap: 3rem;
+    row-gap: 5.7rem;
+    padding: 0 2.4rem;
+
+    @media (max-width: ${theme.breakPoint.media.tablet}) {
+      grid-template-columns: repeat(2, 44.94vw);
+      grid-auto-rows: 53.09vw;
+      column-gap: 3.4rem;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      grid-template-columns: 100%;
+      grid-auto-rows: 119.45vw;
+      column-gap: 0;
+    }
+  `}
+`;

--- a/src/components/projects/ProjectList/ProjectList.tsx
+++ b/src/components/projects/ProjectList/ProjectList.tsx
@@ -1,0 +1,24 @@
+import { LATEST_COUNT, ProjectType } from '@/components/common/ArticlePreview/ArticlePreview';
+import { ArticlePreview } from '@/components';
+import * as Styled from './ProjectList.styled';
+
+interface ProjectListProps {
+  projects: ProjectType[];
+}
+
+const ProjectList = ({ projects }: ProjectListProps) => {
+  const distinguishedLatestProjects = projects.map((project, index) => ({
+    ...project,
+    isLatest: index < LATEST_COUNT,
+  }));
+
+  return (
+    <Styled.ProjectList>
+      {distinguishedLatestProjects.map((project) => (
+        <ArticlePreview article={project} key={project.slug} />
+      ))}
+    </Styled.ProjectList>
+  );
+};
+
+export default ProjectList;

--- a/src/components/projects/ProjectsSection/ProjectsSection.styled.ts
+++ b/src/components/projects/ProjectsSection/ProjectsSection.styled.ts
@@ -1,0 +1,7 @@
+import styled from '@emotion/styled';
+
+export const ProjectsSection = styled.section`
+  margin: 3.2rem auto 7rem;
+  max-width: 120rem;
+  width: 100%;
+`;

--- a/src/components/projects/ProjectsSection/ProjectsSection.tsx
+++ b/src/components/projects/ProjectsSection/ProjectsSection.tsx
@@ -1,0 +1,17 @@
+import { ProjectList } from '@/components';
+import { ProjectType } from '@/components/common/ArticlePreview/ArticlePreview';
+import * as Styled from './ProjectsSection.styled';
+
+interface ProjectsSectionProps {
+  projects: ProjectType[];
+}
+
+const ProjectsSection = ({ projects }: ProjectsSectionProps) => {
+  return (
+    <Styled.ProjectsSection>
+      <ProjectList projects={projects} />
+    </Styled.ProjectsSection>
+  );
+};
+
+export default ProjectsSection;

--- a/src/components/projects/index.ts
+++ b/src/components/projects/index.ts
@@ -1,0 +1,2 @@
+export { default as ProjectList } from './ProjectList/ProjectList';
+export { default as ProjectsSection } from './ProjectsSection/ProjectsSection';

--- a/src/gatsby/createPages.js
+++ b/src/gatsby/createPages.js
@@ -1,0 +1,83 @@
+const path = require('path');
+
+exports.createArticlePage = async ({ graphql, reporter, actions }) => {
+  const { createPage } = actions;
+
+  const articleTemplate = path.resolve(`src/templates/articleTemplate.tsx`);
+
+  const slugResult = await graphql(
+    `
+      query getArticleSlugs {
+        allContentfulArticles {
+          nodes {
+            slug
+          }
+        }
+      }
+    `,
+    { limit: 1000 },
+  );
+
+  if (slugResult.errors) {
+    reporter.panicOnBuild(slugResult.errors);
+    return;
+  }
+
+  if (!slugResult.data) {
+    reporter.panicOnBuild('graphql query result is empty');
+    return;
+  }
+
+  const articleSlugs = slugResult.data.allContentfulArticles.nodes;
+
+  articleSlugs.forEach(({ slug }) => {
+    createPage({
+      path: `article/${slug}`,
+      component: articleTemplate,
+      context: {
+        slug,
+      },
+    });
+  });
+};
+
+exports.createProjectPage = async ({ graphql, reporter, actions }) => {
+  const { createPage } = actions;
+
+  const projectTemplate = path.resolve(`src/templates/projectTemplate.tsx`);
+
+  const slugResult = await graphql(
+    `
+      query getProjectSlugs {
+        allContentfulProject {
+          nodes {
+            slug
+          }
+        }
+      }
+    `,
+    { limit: 1000 },
+  );
+
+  if (slugResult.errors) {
+    reporter.panicOnBuild(slugResult.errors);
+    return;
+  }
+
+  if (!slugResult.data) {
+    reporter.panicOnBuild('graphql query result is empty');
+    return;
+  }
+
+  const projectSlugs = slugResult.data.allContentfulProject.nodes;
+
+  projectSlugs.forEach(({ slug }) => {
+    createPage({
+      path: `projects/${slug}`,
+      component: projectTemplate,
+      context: {
+        slug,
+      },
+    });
+  });
+};

--- a/src/pages/projects.tsx
+++ b/src/pages/projects.tsx
@@ -1,0 +1,39 @@
+import { Layout, ProjectsSection, SubHeader } from '@/components';
+import { ProjectType } from '@/components/common/ArticlePreview/ArticlePreview';
+import { graphql } from 'gatsby';
+
+interface ProjectsPageProps {
+  data: {
+    allContentfulProject: {
+      nodes: ProjectType[];
+    };
+  };
+}
+
+const ProjectsPage = ({ data }: ProjectsPageProps) => {
+  const projects = data.allContentfulProject.nodes;
+  return (
+    <Layout>
+      <SubHeader color="yellow" title="Projects" description="매시업 디자인팀의 프로젝트 이야기" />
+      <ProjectsSection projects={projects} />
+    </Layout>
+  );
+};
+
+export default ProjectsPage;
+
+export const query = graphql`
+  query getProjectPageData {
+    allContentfulProject(sort: { fields: createdAt, order: DESC }) {
+      nodes {
+        title
+        slug
+        tag
+        thumbnail {
+          gatsbyImageData
+        }
+        createdAt(formatString: "MMMM DD, YYYY")
+      }
+    }
+  }
+`;

--- a/src/templates/projectTemplate.tsx
+++ b/src/templates/projectTemplate.tsx
@@ -1,0 +1,38 @@
+import { Layout, ProjectTemplateLayout } from '@/components';
+import { ProjectType } from '@/components/common/ArticlePreview/ArticlePreview';
+import { graphql } from 'gatsby';
+
+interface ProjectTemplateProps {
+  data: {
+    contentfulProject: ProjectType;
+  };
+}
+
+const ArticleTemplate = ({ data }: ProjectTemplateProps) => {
+  const { contentfulProject } = data;
+
+  return (
+    <Layout>
+      <ProjectTemplateLayout project={contentfulProject} />
+    </Layout>
+  );
+};
+
+export default ArticleTemplate;
+
+export const queryMarkdownDataBySlug = graphql`
+  query getProjectDetail($slug: String) {
+    contentfulProject(slug: { eq: $slug }) {
+      title
+      slug
+      tag
+      thumbnail {
+        gatsbyImageData
+      }
+      contentImages {
+        gatsbyImageData
+      }
+      createdAt(formatString: "YYYY. MM. DD")
+    }
+  }
+`;


### PR DESCRIPTION
## 변경사항

- Contentful에 작성되어 있는 Project를 graphql로 쿼링하여 projects페이지 UI를 렌더링
- slug에 맞는 프로젝트 데이터를 graphql로 쿼링하여 project 상세페이지 UI를 렌더링
